### PR TITLE
[FEAT] 깃랩 백업 로직 github action으로 작성

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,0 +1,47 @@
+name: Sync to GitLab Mono Repo
+
+on:
+  push:
+    branches: [ "main" ]  # 필요하면 master로 변경
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. GitHub 현재 레포 가져오기
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      # 2. GitLab mono repo clone
+      - name: Clone GitLab repo
+        run: |
+          git clone https://oauth2:${{ secrets.GITLAB_TOKEN }}@lab.ssafy.com/s14-final/S14P31A108.git mono-repo
+
+      # 3. repo 이름 변수 설정
+      - name: Set repo name
+        run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
+
+      # 4. (안전) 폴더 생성
+      - name: Ensure directory exists
+        run: mkdir -p mono-repo/$REPO_NAME
+
+      # 5. 파일 동기화
+      - name: Sync files
+        run: |
+          rsync -av --delete ./ mono-repo/$REPO_NAME/ \
+          --exclude '.git' \
+          --exclude '.github'
+
+      # 6. commit & push
+      - name: Commit & Push
+        run: |
+          cd mono-repo
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          git pull origin master --rebase || echo "no remote branch"
+
+          git add .
+          git commit -m "sync: $REPO_NAME updated from GitHub" || echo "No changes"
+          git push


### PR DESCRIPTION
  ✨ 작업 개요
                                                                                                                                        
  GitHub Actions를 통해 main 브랜치에 push될 때마다 GitLab 모노레포(S14P31A108)로 코드를 자동 동기화하는 백업 워크플로우를 추가했습니다.                                      
                                                                           
  📝 변경 사항                                                                              
             
  - .github/workflows/sync-to-gitlab.yml 추가                                                                                         
    - main 브랜치 push 시 트리거
    - GitLab 모노레포를 clone 후 seeker-client/ 하위 폴더로 rsync --delete 동기화 (.git, .github 제외)
    - 변경사항이 있을 경우 GitLab master 브랜치로 commit & push
  - GitLab 기본 브랜치(master)에 맞춰 git pull origin master --rebase 적용

  🔗 관련 이슈

  ✅ 체크리스트

  - 로컬에서 빌드 및 테스트를 통과했습니다. (워크플로우 파일만 추가되어 빌드 영향 없음)
  - 관련 문서를 업데이트했습니다. (필요한 경우)
  - 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

  💬 리뷰어에게

  - 워크플로우가 동작하려면 본 레포 Settings → Secrets and variables → Actions에 GITLAB_TOKEN이 등록되어 있어야 합니다.
  (seeker-agent에서 사용한 토큰과 동일하게 설정해 주세요.)
  - GitLab 모노레포 기본 브랜치를 master로 가정했습니다. 만약 다르다면 sync-to-gitlab.yml의 git pull origin master 부분 수정이
  필요합니다.
  - 최초 1회 push 후 GitLab 모노레포 seeker-client/ 하위에 정상적으로 파일이 들어왔는지 확인 부탁드립니다.