### PR TITLE
[FEAT] 기본 UI 셸 구성 — 다크 네이비 테마 + 사이드바/탑바 + 라우팅

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout source repo
         uses: actions/checkout@v4
 
-      # 2. GitLab mono repo clone
+      # 2. GitLab mono repo clone (소스 디렉터리 밖에 clone — 무한 재귀 방지)
       - name: Clone GitLab repo
         run: |
-          git clone https://oauth2:${{ secrets.GITLAB_TOKEN }}@lab.ssafy.com/s14-final/S14P31A108.git mono-repo
+          git clone https://oauth2:${{ secrets.GITLAB_TOKEN }}@lab.ssafy.com/s14-final/S14P31A108.git /tmp/mono-repo
 
       # 3. repo 이름 변수 설정
       - name: Set repo name
@@ -24,19 +24,19 @@ jobs:
 
       # 4. (안전) 폴더 생성
       - name: Ensure directory exists
-        run: mkdir -p mono-repo/$REPO_NAME
+        run: mkdir -p /tmp/mono-repo/$REPO_NAME
 
       # 5. 파일 동기화
       - name: Sync files
         run: |
-          rsync -av --delete ./ mono-repo/$REPO_NAME/ \
+          rsync -av --delete ./ /tmp/mono-repo/$REPO_NAME/ \
           --exclude '.git' \
           --exclude '.github'
 
       # 6. commit & push
       - name: Commit & Push
         run: |
-          cd mono-repo
+          cd /tmp/mono-repo
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,13 @@ entities/service/
 ### 스타일
 - Tailwind 우선. `@apply`는 `shared/ui` 내부에서만.
 - 색상은 CSS 변수 토큰(`bg-background`, `text-foreground` 등)을 사용. 하드코딩된 hex/rgb 금지.
-- 다크 모드는 `dark` 클래스 기반 (이미 설정됨).
+- **앱은 상시 다크모드**. `<html class="dark">`가 고정되어 있고 라이트 테마로 전환할 계획 없음. `dark:` prefix 쓰지 말고 토큰만 사용. `:root`의 light 토큰 블록은 shadcn 호환용으로 남겨둔 것일 뿐 실제로는 동작하지 않음.
+- **사이드바 전용 토큰**: `--sidebar`, `--sidebar-active`, `--sidebar-foreground`, `--sidebar-active-foreground`, `--sidebar-border`가 별도 존재. **사이드바 내부에서만** 사용하고, 일반 패널/카드는 `bg-card`/`bg-background` 사용.
+
+### 레이아웃
+- 화면 쉘(탑바 + 사이드바 + 메인 영역)은 `widgets/app-layout`이 단독 책임짐.
+- 페이지는 자기 콘텐츠만 렌더. **페이지에서 레이아웃·사이드바·탑바·전역 패딩 건드리지 말 것.**
+- 탑바는 최상단 전체 폭, 그 아래 왼쪽 사이드바 + 오른쪽 메인 스크롤 영역 구조.
 
 ### shadcn/ui
 - `npx shadcn@latest add <component>` 실행 시 `src/shared/ui/`에 생성됨 (components.json에 설정됨).
@@ -102,6 +108,15 @@ entities/service/
 - `npm test` — Vitest 1회 실행
 - `npm run test:watch` — Vitest watch
 - `npm run lint` / `npm run format`
+
+## 새 라우트 추가 절차
+
+1. `src/pages/<slug>-page/ui/<slug>-page.tsx` 작성 (PascalCase export, `kebab-case` 파일명).
+2. `src/pages/<slug>-page/index.ts`에 public API 배럴.
+3. `src/app/router/routes.tsx`에 라우트 등록.
+4. 사이드바에 노출해야 하면 `src/widgets/app-sidebar/model/nav-items.ts`에 항목 추가.
+
+> 사이드바와 라우터는 자동 연결되지 않음. 둘 다 손대야 메뉴로 접근 가능.
 
 ## 금지사항
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,11 @@
+import { RouterProvider } from 'react-router-dom'
+import { QueryProvider } from './providers/query-provider'
+import { router } from './router/routes'
+
 export default function App() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
-      <div className="text-center">
-        <h1 className="text-3xl font-semibold">Seeker APM</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Scaffold ready. Start building your dashboards.
-        </p>
-      </div>
-    </div>
+    <QueryProvider>
+      <RouterProvider router={router} />
+    </QueryProvider>
   )
 }

--- a/src/app/providers/query-provider.tsx
+++ b/src/app/providers/query-provider.tsx
@@ -1,0 +1,19 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState, type ReactNode } from 'react'
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  )
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/src/app/router/routes.tsx
+++ b/src/app/router/routes.tsx
@@ -1,0 +1,24 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom'
+import { AppLayout } from '@/widgets/app-layout'
+import { DashboardPage } from '@/pages/dashboard-page'
+import { TracesPage } from '@/pages/traces-page'
+import { ErrorsPage } from '@/pages/errors-page'
+import { ReportsPage } from '@/pages/reports-page'
+import { AlertsPage } from '@/pages/alerts-page'
+import { SettingsPage } from '@/pages/settings-page'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <Navigate to="/dashboard" replace /> },
+      { path: 'dashboard', element: <DashboardPage /> },
+      { path: 'traces', element: <TracesPage /> },
+      { path: 'errors', element: <ErrorsPage /> },
+      { path: 'reports', element: <ReportsPage /> },
+      { path: 'alerts', element: <AlertsPage /> },
+      { path: 'settings', element: <SettingsPage /> },
+    ],
+  },
+])

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
     --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
+    --primary: 245 75% 60%;
     --primary-foreground: 210 40% 98%;
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
@@ -18,34 +18,46 @@
     --muted-foreground: 215.4 16.3% 46.9%;
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 15 90% 60%;
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --ring: 245 75% 60%;
     --radius: 0.5rem;
+
+    --sidebar: 230 35% 7%;
+    --sidebar-foreground: 220 15% 65%;
+    --sidebar-active: 230 30% 14%;
+    --sidebar-active-foreground: 0 0% 100%;
+    --sidebar-border: 230 25% 14%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
+    --background: 230 35% 7%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 230 30% 10%;
     --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
+    --popover: 230 30% 10%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
+    --primary: 245 85% 68%;
+    --primary-foreground: 230 35% 7%;
+    --secondary: 230 25% 15%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
+    --muted: 230 25% 15%;
+    --muted-foreground: 220 15% 55%;
+    --accent: 230 25% 15%;
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 15 90% 65%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 230 25% 15%;
+    --input: 230 25% 15%;
+    --ring: 245 85% 68%;
+
+    --sidebar: 230 35% 7%;
+    --sidebar-foreground: 220 15% 60%;
+    --sidebar-active: 230 30% 14%;
+    --sidebar-active-foreground: 0 0% 100%;
+    --sidebar-border: 230 25% 14%;
   }
 }
 

--- a/src/pages/alerts-page/index.ts
+++ b/src/pages/alerts-page/index.ts
@@ -1,0 +1,1 @@
+export { AlertsPage } from './ui/alerts-page'

--- a/src/pages/alerts-page/ui/alerts-page.tsx
+++ b/src/pages/alerts-page/ui/alerts-page.tsx
@@ -1,0 +1,8 @@
+export function AlertsPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Alerts</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/pages/dashboard-page/index.ts
+++ b/src/pages/dashboard-page/index.ts
@@ -1,0 +1,1 @@
+export { DashboardPage } from './ui/dashboard-page'

--- a/src/pages/dashboard-page/ui/dashboard-page.tsx
+++ b/src/pages/dashboard-page/ui/dashboard-page.tsx
@@ -1,0 +1,8 @@
+export function DashboardPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/pages/errors-page/index.ts
+++ b/src/pages/errors-page/index.ts
@@ -1,0 +1,1 @@
+export { ErrorsPage } from './ui/errors-page'

--- a/src/pages/errors-page/ui/errors-page.tsx
+++ b/src/pages/errors-page/ui/errors-page.tsx
@@ -1,0 +1,8 @@
+export function ErrorsPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Errors</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/pages/reports-page/index.ts
+++ b/src/pages/reports-page/index.ts
@@ -1,0 +1,1 @@
+export { ReportsPage } from './ui/reports-page'

--- a/src/pages/reports-page/ui/reports-page.tsx
+++ b/src/pages/reports-page/ui/reports-page.tsx
@@ -1,0 +1,8 @@
+export function ReportsPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Reports</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/pages/settings-page/index.ts
+++ b/src/pages/settings-page/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage } from './ui/settings-page'

--- a/src/pages/settings-page/ui/settings-page.tsx
+++ b/src/pages/settings-page/ui/settings-page.tsx
@@ -1,0 +1,8 @@
+export function SettingsPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/pages/traces-page/index.ts
+++ b/src/pages/traces-page/index.ts
@@ -1,0 +1,1 @@
+export { TracesPage } from './ui/traces-page'

--- a/src/pages/traces-page/ui/traces-page.tsx
+++ b/src/pages/traces-page/ui/traces-page.tsx
@@ -1,0 +1,8 @@
+export function TracesPage() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Traces</h1>
+      <p className="text-sm text-muted-foreground">Coming soon.</p>
+    </div>
+  )
+}

--- a/src/widgets/app-layout/index.ts
+++ b/src/widgets/app-layout/index.ts
@@ -1,0 +1,1 @@
+export { AppLayout } from './ui/app-layout'

--- a/src/widgets/app-layout/ui/app-layout.tsx
+++ b/src/widgets/app-layout/ui/app-layout.tsx
@@ -4,11 +4,11 @@ import { AppTopbar } from '@/widgets/app-topbar'
 
 export function AppLayout() {
   return (
-    <div className="flex h-screen w-full bg-background text-foreground">
-      <AppSidebar />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <AppTopbar />
-        <main className="flex-1 overflow-auto p-4 md:p-6">
+    <div className="flex h-screen w-full flex-col bg-background text-foreground">
+      <AppTopbar />
+      <div className="flex min-h-0 flex-1">
+        <AppSidebar />
+        <main className="min-w-0 flex-1 overflow-auto p-4 md:p-6">
           <Outlet />
         </main>
       </div>

--- a/src/widgets/app-layout/ui/app-layout.tsx
+++ b/src/widgets/app-layout/ui/app-layout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom'
+import { AppSidebar } from '@/widgets/app-sidebar'
+import { AppTopbar } from '@/widgets/app-topbar'
+
+export function AppLayout() {
+  return (
+    <div className="flex h-screen w-full bg-background text-foreground">
+      <AppSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <AppTopbar />
+        <main className="flex-1 overflow-auto p-4 md:p-6">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/app-sidebar/index.ts
+++ b/src/widgets/app-sidebar/index.ts
@@ -1,0 +1,1 @@
+export { AppSidebar } from './ui/app-sidebar'

--- a/src/widgets/app-sidebar/model/nav-items.ts
+++ b/src/widgets/app-sidebar/model/nav-items.ts
@@ -1,0 +1,27 @@
+import {
+  AlertCircle,
+  BarChart3,
+  Bell,
+  BrainCircuit,
+  LayoutGrid,
+  Settings,
+  type LucideIcon,
+} from 'lucide-react'
+
+export type NavItem = {
+  to: string
+  label: string
+  icon: LucideIcon
+}
+
+export const primaryNavItems: NavItem[] = [
+  { to: '/dashboard', label: 'Dashboard', icon: LayoutGrid },
+  { to: '/traces', label: 'Traces', icon: BarChart3 },
+  { to: '/errors', label: 'Errors', icon: AlertCircle },
+  { to: '/reports', label: 'Reports', icon: BrainCircuit },
+  { to: '/alerts', label: 'Alerts', icon: Bell },
+]
+
+export const secondaryNavItems: NavItem[] = [
+  { to: '/settings', label: 'Settings', icon: Settings },
+]

--- a/src/widgets/app-sidebar/ui/app-sidebar.tsx
+++ b/src/widgets/app-sidebar/ui/app-sidebar.tsx
@@ -1,0 +1,55 @@
+import { NavLink } from 'react-router-dom'
+import { cn } from '@/shared/lib'
+import { primaryNavItems, secondaryNavItems, type NavItem } from '../model/nav-items'
+
+function SidebarLink({ item }: { item: NavItem }) {
+  const Icon = item.icon
+  return (
+    <NavLink
+      to={item.to}
+      className={({ isActive }) =>
+        cn(
+          'group relative flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors',
+          'text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-sidebar-active-foreground',
+          isActive && 'bg-sidebar-active text-sidebar-active-foreground',
+        )
+      }
+    >
+      {({ isActive }) => (
+        <>
+          <span
+            aria-hidden
+            className={cn(
+              'absolute left-0 top-1/2 h-6 w-[2px] -translate-y-1/2 rounded-r bg-primary opacity-0 transition-opacity',
+              isActive && 'opacity-100',
+            )}
+          />
+          <Icon className="h-[18px] w-[18px] shrink-0" />
+          <span className="hidden md:inline">{item.label}</span>
+        </>
+      )}
+    </NavLink>
+  )
+}
+
+export function AppSidebar() {
+  return (
+    <aside
+      className={cn(
+        'flex h-screen shrink-0 flex-col border-r border-sidebar-border bg-sidebar',
+        'w-16 md:w-56 lg:w-60',
+      )}
+    >
+      <nav className="flex flex-1 flex-col gap-1 p-2 pt-4 md:p-3 md:pt-4">
+        {primaryNavItems.map((item) => (
+          <SidebarLink key={item.to} item={item} />
+        ))}
+      </nav>
+      <nav className="flex flex-col gap-1 border-t border-sidebar-border p-2 md:p-3">
+        {secondaryNavItems.map((item) => (
+          <SidebarLink key={item.to} item={item} />
+        ))}
+      </nav>
+    </aside>
+  )
+}

--- a/src/widgets/app-sidebar/ui/app-sidebar.tsx
+++ b/src/widgets/app-sidebar/ui/app-sidebar.tsx
@@ -36,7 +36,7 @@ export function AppSidebar() {
   return (
     <aside
       className={cn(
-        'flex h-screen shrink-0 flex-col border-r border-sidebar-border bg-sidebar',
+        'flex h-full shrink-0 flex-col border-r border-sidebar-border bg-sidebar',
         'w-16 md:w-56 lg:w-60',
       )}
     >

--- a/src/widgets/app-topbar/index.ts
+++ b/src/widgets/app-topbar/index.ts
@@ -1,0 +1,1 @@
+export { AppTopbar } from './ui/app-topbar'

--- a/src/widgets/app-topbar/ui/app-topbar.tsx
+++ b/src/widgets/app-topbar/ui/app-topbar.tsx
@@ -1,0 +1,53 @@
+import { Bell, Box, CircleHelp } from 'lucide-react'
+import { cn } from '@/shared/lib'
+
+type AppTopbarProps = {
+  hasUnreadAlerts?: boolean
+}
+
+export function AppTopbar({ hasUnreadAlerts = false }: AppTopbarProps) {
+  return (
+    <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-3 md:px-6">
+      <div className="flex items-center gap-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/20 text-primary">
+          <Box className="h-[18px] w-[18px]" />
+        </div>
+        <span className="text-base font-semibold tracking-tight text-foreground">Seeker</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <IconButton aria-label="Help">
+          <CircleHelp className="h-[18px] w-[18px]" />
+        </IconButton>
+        <IconButton aria-label="Notifications">
+          <Bell className="h-[18px] w-[18px]" />
+          <span
+            aria-hidden
+            className={cn(
+              'absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-destructive ring-2 ring-card',
+              !hasUnreadAlerts && 'hidden',
+            )}
+          />
+        </IconButton>
+      </div>
+    </header>
+  )
+}
+
+function IconButton({
+  children,
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'relative inline-flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,13 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          active: 'hsl(var(--sidebar-active))',
+          'active-foreground': 'hsl(var(--sidebar-active-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## ✨ 작업 개요

APM 대시보드의 기본 UI 셸을 구성했습니다. 다크 네이비 테마 컬러 토큰을 잡고, 사이드바 + 탑바 + 메인 영역의 레이아웃 쉘을 만든 뒤, 6개 페이지(Dashboard/Traces/Errors/Reports/Alerts/Settings)를 빈 스켈레톤으로 연결했습니다.

## 📝 변경 사항

- **테마**: `index.css` dark 변수를 네이비/인디고 톤으로 교체, `sidebar` 전용 토큰(`--sidebar`, `--sidebar-active` 등) 추가. `<html class="dark">` 고정으로 상시 다크모드.
- **위젯**:
  - `widgets/app-sidebar` — 반응형(sm: 아이콘만 `w-16`, md+: 라벨 `w-56/60`), 활성 시 좌측 인디고 인디케이터 바
  - `widgets/app-topbar` — Seeker 로고 + Help/Bell, `hasUnreadAlerts` prop으로 배지 토글(기본 숨김)
  - `widgets/app-layout` — 탑바(상단 전체 폭) + 사이드바(좌측) + `<Outlet/>` 쉘
- **페이지**: `dashboard/traces/errors/reports/alerts/settings` 6종 placeholder (FSD 구조 준수)
- **라우팅/Provider**: `createBrowserRouter`로 6개 라우트 + `/` → `/dashboard` 리다이렉트, `QueryProvider` 래퍼 신설(staleTime 30s, refetchOnWindowFocus off)
- **문서**: `CLAUDE.md`에 다크모드/사이드바 토큰/레이아웃 쉘/새 라우트 추가 절차 규칙 반영

## 🔗 관련 이슈

Closes #4

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다. (`npm run build` 통과, dev 서버 기동 확인)
- [x] 관련 문서를 업데이트했습니다. (`CLAUDE.md`)
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

## 💬 리뷰어에게

- 컬러 토큰 값(`hsl()`)이 이미지 톤과 맞는지 눈으로 한 번 봐주세요. 필요하면 `src/index.css`의 `.dark` 블록 수치만 조정하면 됩니다.
- 사이드바는 `sm` 미만에서 아이콘만 표시되도록 처리했는데, 모바일 햄버거/드로어가 필요하면 별도 티켓으로 뺄지 논의 필요합니다.
- `widgets`끼리는 서로 직접 임포트하지 않는 FSD 규칙에 따라, `app-layout`이 `app-sidebar`/`app-topbar`를 조립만 하고 있습니다.