### PR TITLE
[FEAT] 에이전트 메트릭 패널 + 토폴로지 클릭 연동

### DIFF
--- a/src/entities/server-metric/index.ts
+++ b/src/entities/server-metric/index.ts
@@ -1,0 +1,5 @@
+export type { ServerMetric } from './model/types'
+export { mockMetricsByAgent } from './model/mock'
+export { formatMs, formatPercent, formatCount } from './lib/format'
+export { MetricCard } from './ui/metric-card'
+export type { MetricCardProps } from './ui/metric-card'

--- a/src/entities/server-metric/lib/format.ts
+++ b/src/entities/server-metric/lib/format.ts
@@ -1,0 +1,11 @@
+export function formatMs(value: number): string {
+  return Math.round(value).toLocaleString()
+}
+
+export function formatPercent(value: number, fractionDigits = 2): string {
+  return (value * 100).toFixed(fractionDigits)
+}
+
+export function formatCount(value: number): string {
+  return Math.round(value).toLocaleString()
+}

--- a/src/entities/server-metric/model/mock.ts
+++ b/src/entities/server-metric/model/mock.ts
@@ -1,0 +1,62 @@
+import type { AgentIdValue } from '@/entities/topology'
+import { USER_AGENT_ID } from '@/entities/topology'
+import type { ServerMetric } from './types'
+
+export const mockMetricsByAgent: Record<AgentIdValue, ServerMetric> = {
+  [USER_AGENT_ID]: {
+    totalCount: 50_000,
+    errorCount: 11,
+    errorRate: 0.00022,
+    p99: 142,
+    p95: 98,
+    p90: 76,
+  },
+  'gateway-1': {
+    totalCount: 48_300,
+    errorCount: 96,
+    errorRate: 0.002,
+    p99: 118,
+    p95: 84,
+    p90: 62,
+  },
+  'order-1': {
+    totalCount: 21_400,
+    errorCount: 257,
+    errorRate: 0.012,
+    p99: 187,
+    p95: 121,
+    p90: 94,
+  },
+  'product-1': {
+    totalCount: 18_900,
+    errorCount: 0,
+    errorRate: 0,
+    p99: 71,
+    p95: 48,
+    p90: 36,
+  },
+  'payment-1': {
+    totalCount: 9_800,
+    errorCount: 706,
+    errorRate: 0.072,
+    p99: 412,
+    p95: 268,
+    p90: 198,
+  },
+  'order-db': {
+    totalCount: 67_500,
+    errorCount: 0,
+    errorRate: 0,
+    p99: 22,
+    p95: 14,
+    p90: 9,
+  },
+  'product-db': {
+    totalCount: 43_800,
+    errorCount: 0,
+    errorRate: 0,
+    p99: 18,
+    p95: 11,
+    p90: 7,
+  },
+}

--- a/src/entities/server-metric/model/types.ts
+++ b/src/entities/server-metric/model/types.ts
@@ -1,0 +1,8 @@
+export interface ServerMetric {
+  totalCount: number
+  errorCount: number
+  errorRate: number
+  p99: number
+  p95: number
+  p90: number
+}

--- a/src/entities/server-metric/ui/metric-card.tsx
+++ b/src/entities/server-metric/ui/metric-card.tsx
@@ -1,0 +1,45 @@
+import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/shared/lib'
+
+export interface MetricCardProps {
+  label: string
+  value: string
+  unit?: string
+  icon: LucideIcon
+  tone?: 'default' | 'destructive'
+  className?: string
+}
+
+export function MetricCard({
+  label,
+  value,
+  unit,
+  icon: Icon,
+  tone = 'default',
+  className,
+}: MetricCardProps) {
+  return (
+    <div
+      className={cn(
+        'relative flex min-h-[112px] flex-col justify-between overflow-hidden rounded-lg border border-border/60 bg-card/60 p-5',
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <span>{label}</span>
+        <Icon className="h-5 w-5 opacity-40" aria-hidden />
+      </div>
+      <div className="flex items-baseline gap-1">
+        <span
+          className={cn(
+            'text-4xl font-semibold tabular-nums',
+            tone === 'destructive' ? 'text-destructive' : 'text-foreground',
+          )}
+        >
+          {value}
+        </span>
+        {unit && <span className="text-sm text-muted-foreground">{unit}</span>}
+      </div>
+    </div>
+  )
+}

--- a/src/entities/topology/index.ts
+++ b/src/entities/topology/index.ts
@@ -1,6 +1,7 @@
 export type { AgentIdValue, NodeData, EdgeData, TopologyData } from './model/types'
 export { USER_AGENT_ID } from './model/types'
 export { mockTopology } from './model/mock'
+export { useTopologySelection } from './model/selection-store'
 export { iconForAgentType } from './lib/agent-icon'
 export { TopologyNode, NODE_SIZE } from './ui/topology-node'
 export { TopologyEdge } from './ui/topology-edge'

--- a/src/entities/topology/model/selection-store.ts
+++ b/src/entities/topology/model/selection-store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+import type { AgentIdValue } from './types'
+import { USER_AGENT_ID } from './types'
+
+interface TopologySelectionState {
+  selectedAgentId: AgentIdValue
+  setSelectedAgentId: (id: AgentIdValue) => void
+  clearSelection: () => void
+}
+
+export const useTopologySelection = create<TopologySelectionState>((set) => ({
+  selectedAgentId: USER_AGENT_ID,
+  setSelectedAgentId: (id) => set({ selectedAgentId: id }),
+  clearSelection: () => set({ selectedAgentId: USER_AGENT_ID }),
+}))

--- a/src/features/topology-graph/model/use-zoom-pan.ts
+++ b/src/features/topology-graph/model/use-zoom-pan.ts
@@ -77,6 +77,8 @@ export function useZoomPan(
     startClientY: number
     startState: ZoomState
     moved: boolean
+    pointerId: number
+    target: Element
   } | null>(null)
   const recentDragRef = useRef(false)
 
@@ -110,8 +112,9 @@ export function useZoomPan(
       startClientY: e.clientY,
       startState: stateRef.current,
       moved: false,
+      pointerId: e.pointerId,
+      target: e.currentTarget as Element,
     }
-    ;(e.currentTarget as Element).setPointerCapture(e.pointerId)
   }, [])
 
   const onPointerMove = useCallback(
@@ -121,6 +124,9 @@ export function useZoomPan(
       const dx = e.clientX - drag.startClientX
       const dy = e.clientY - drag.startClientY
       if (!drag.moved && Math.hypot(dx, dy) < PAN_THRESHOLD) return
+      if (!drag.moved) {
+        drag.target.setPointerCapture(drag.pointerId)
+      }
       drag.moved = true
       setState({
         x: drag.startState.x + dx,

--- a/src/features/topology-graph/ui/topology-graph.tsx
+++ b/src/features/topology-graph/ui/topology-graph.tsx
@@ -1,7 +1,7 @@
 import { useId, useMemo, useRef, useState } from 'react'
 import { ParentSize } from '@visx/responsive'
 import type { TopologyData, AgentIdValue, NodeData } from '@/entities/topology'
-import { TopologyEdge, TopologyNode } from '@/entities/topology'
+import { TopologyEdge, TopologyNode, useTopologySelection } from '@/entities/topology'
 import { cn } from '@/shared/lib'
 import { layeredLayout } from '../lib/layered-layout'
 import { useZoomPan } from '../model/use-zoom-pan'
@@ -60,7 +60,9 @@ function TopologyGraphCanvas({
   const clipId = `topology-clip-${idBase}`
   const [hover, setHover] = useState<HoverTarget>(null)
   const [tooltipPos, setTooltipPos] = useState<TooltipPos | null>(null)
-  const [selected, setSelected] = useState<AgentIdValue | null>(null)
+  const selected = useTopologySelection((s) => s.selectedAgentId)
+  const setSelectedAgentId = useTopologySelection((s) => s.setSelectedAgentId)
+  const clearSelection = useTopologySelection((s) => s.clearSelection)
 
   const {
     positions,
@@ -92,7 +94,8 @@ function TopologyGraphCanvas({
 
   const onNodeClick = (agentId: AgentIdValue) => {
     if (consumeRecentDrag()) return
-    setSelected((prev) => (prev === agentId ? null : agentId))
+    if (agentId === selected) clearSelection()
+    else setSelectedAgentId(agentId)
   }
 
   const hoveredNode = hover?.kind === 'node' ? (nodeById.get(hover.agentId) ?? null) : null

--- a/src/pages/dashboard-page/ui/dashboard-page.tsx
+++ b/src/pages/dashboard-page/ui/dashboard-page.tsx
@@ -5,6 +5,7 @@ import {
   type TimeRange,
 } from '@/features/time-range-picker'
 import { TopologyPanel } from '@/widgets/topology-panel'
+import { MetricPanel } from '@/widgets/metric-panel'
 
 export function DashboardPage() {
   const [range, setRange] = useState<TimeRange>(() => createPresetRange('5m'))
@@ -19,6 +20,7 @@ export function DashboardPage() {
         />
       </div>
       <TopologyPanel />
+      <MetricPanel />
     </div>
   )
 }

--- a/src/widgets/metric-panel/index.ts
+++ b/src/widgets/metric-panel/index.ts
@@ -1,0 +1,1 @@
+export { MetricPanel } from './ui/metric-panel'

--- a/src/widgets/metric-panel/ui/metric-panel.tsx
+++ b/src/widgets/metric-panel/ui/metric-panel.tsx
@@ -1,0 +1,48 @@
+import { Activity, AlertCircle, AlertTriangle, Timer } from 'lucide-react'
+import { mockTopology, USER_AGENT_ID, useTopologySelection } from '@/entities/topology'
+import {
+  MetricCard,
+  formatCount,
+  formatMs,
+  formatPercent,
+  mockMetricsByAgent,
+} from '@/entities/server-metric'
+
+export function MetricPanel() {
+  const selectedAgentId = useTopologySelection((s) => s.selectedAgentId)
+  const agent = mockTopology.nodes.find((n) => n.agentId === selectedAgentId)
+  const metric = mockMetricsByAgent[selectedAgentId] ?? mockMetricsByAgent[USER_AGENT_ID]
+
+  const errorCountTone = metric.errorCount > 0 ? 'destructive' : 'default'
+
+  return (
+    <section className="mx-auto w-full max-w-[1240px] space-y-3">
+      <h2 className="px-1 text-sm font-semibold tracking-wide text-foreground">
+        {agent?.agentName ?? 'USER'}
+      </h2>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <MetricCard
+          label="Total Count"
+          value={formatCount(metric.totalCount)}
+          icon={Activity}
+        />
+        <MetricCard
+          label="Error Count"
+          value={formatCount(metric.errorCount)}
+          icon={AlertTriangle}
+          tone={errorCountTone}
+        />
+        <MetricCard
+          label="Error Rate"
+          value={formatPercent(metric.errorRate)}
+          unit="%"
+          icon={AlertCircle}
+          tone="destructive"
+        />
+        <MetricCard label="P99" value={formatMs(metric.p99)} unit="ms" icon={Timer} />
+        <MetricCard label="P95" value={formatMs(metric.p95)} unit="ms" icon={Timer} />
+        <MetricCard label="P90" value={formatMs(metric.p90)} unit="ms" icon={Timer} />
+      </div>
+    </section>
+  )
+}

--- a/src/widgets/topology-panel/ui/topology-panel.tsx
+++ b/src/widgets/topology-panel/ui/topology-panel.tsx
@@ -3,7 +3,7 @@ import { TopologyGraph } from '@/features/topology-graph'
 
 export function TopologyPanel() {
   return (
-    <section className="relative mx-auto h-[62vh] min-h-[460px] max-h-[760px] w-full max-w-[1240px] overflow-hidden rounded-lg border border-border/60 bg-card/60 p-4 sm:p-6">
+    <section className="relative mx-auto h-[48vh] min-h-[320px] max-h-[560px] w-full max-w-[1240px] overflow-hidden rounded-lg border border-border/60 bg-card/60 p-4 sm:p-6">
       <TopologyGraph data={mockTopology} />
     </section>
   )


### PR DESCRIPTION
## ✨ 작업 개요

대시보드에서 토폴로지 노드를 클릭하면 해당 에이전트의 지표(`totalCount`, `errorCount`, `errorRate`, `P99/P95/P90`)가 그 아래 메트릭 패널에 즉시 반영되도록 구현했습니다. 선택된 노드가 없으면 USER 에이전트의 지표를 기본으로 노출합니다. API 연동은 다음 PR에서 진행 예정이며, 이번 PR은 UI 골격 + 선택 상태 + mock 데이터까지입니다.

## 📝 변경 사항

- **선택 스토어 추가** — `entities/topology/model/selection-store.ts`에 Zustand 스토어를 두어 토폴로지와 메트릭 패널이 같은 선택 상태를 공유하도록 함 (기본값 `USER_AGENT_ID`, 같은 노드 재클릭 시 USER로 복귀).
- **server-metric 엔티티 신설** — `ServerMetric` 타입(백엔드 응답 필드와 1:1), 에이전트별 mock 데이터, `formatMs / formatPercent / formatCount` 포맷터, 단일 `MetricCard` 컴포넌트.
- **metric-panel 위젯 신설** — 6장 카드를 `lg:grid-cols-6` 한 줄로 배치, 선택 스토어를 구독하여 자동 갱신. 대시보드 페이지에 `<TopologyPanel />` 아래로 마운트.
- **버그 수정 — 노드 클릭이 발사되지 않던 문제** — `useZoomPan`이 `pointerdown` 즉시 SVG에 `setPointerCapture()`를 걸어 합성 click 이벤트가 SVG로 가로채여 노드 `onClick`이 절대 호출되지 않던 이슈를, 4px 임계값을 넘는 첫 `pointermove` 시점으로 capture를 지연시켜 해결.
- **레이아웃 조정** — 토폴로지 패널 높이 `62vh → 48vh` (`max 760px → 560px`)로 축소해 토폴로지 + 메트릭이 한 화면에 보이도록.

## 🔗 관련 이슈

Closes #11

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다. (`npm run build`, `npm test`)
- [x] 관련 문서를 업데이트했습니다. (필요한 경우) — 해당 없음
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다. (의존성 순서로 5개 커밋 분리)

## 💬 리뷰어에게
<img width="2284" height="350" alt="image" src="https://github.com/user-attachments/assets/b6abaa52-3d7a-4e4a-aa3d-289ee6121ffe" />

아래는 전체 화면 

<img width="2289" height="1246" alt="image" src="https://github.com/user-attachments/assets/fa031bb0-472b-4633-9dae-565f80b8b585" />
