### PR TITLE
[FEAT]  MSW 인프라 + env 토글 (mock/실서버 자동 분기) (#14)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=http://localhost:8080
+VITE_USE_MOCK=true

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=<your_seeker_web_server>
+VITE_USE_MOCK=true

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,3 @@ dist-ssr
 # Env
 .env.*
 !.env.example
-
-# MSW
-public/mockServiceWorker.js

--- a/package.json
+++ b/package.json
@@ -66,5 +66,10 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.9",
     "vitest": "^2.1.2"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.4'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,20 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { App } from '@/app'
+import { env } from '@/shared/config'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+async function bootstrap() {
+  if (env.useMock) {
+    const { worker } = await import('@/mocks/browser')
+    await worker.start({ onUnhandledRequest: 'bypass' })
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+}
+
+bootstrap()

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,4 @@
+import { serverMetricHandlers } from './server-metric'
+import { topologyHandlers } from './topology'
+
+export const handlers = [...topologyHandlers, ...serverMetricHandlers]

--- a/src/mocks/handlers/server-metric.ts
+++ b/src/mocks/handlers/server-metric.ts
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from 'msw'
+import { mockMetricsByAgent } from '@/entities/server-metric'
+import { env } from '@/shared/config'
+
+export const serverMetricHandlers = [
+  http.get(`${env.apiBaseUrl}/dashboard/metrics`, ({ request }) => {
+    const url = new URL(request.url)
+    const agentId = url.searchParams.get('agentId')
+    if (!agentId) {
+      return HttpResponse.json({ message: 'agentId is required' }, { status: 400 })
+    }
+    const metric = mockMetricsByAgent[agentId]
+    if (!metric) {
+      return HttpResponse.json({ message: 'Agent not found' }, { status: 404 })
+    }
+    return HttpResponse.json(metric)
+  }),
+]

--- a/src/mocks/handlers/topology.ts
+++ b/src/mocks/handlers/topology.ts
@@ -1,0 +1,7 @@
+import { http, HttpResponse } from 'msw'
+import { mockTopology } from '@/entities/topology'
+import { env } from '@/shared/config'
+
+export const topologyHandlers = [
+  http.get(`${env.apiBaseUrl}/dashboard/topology`, () => HttpResponse.json(mockTopology)),
+]

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 const envSchema = z.object({
   VITE_API_BASE_URL: z.string().url(),
+  VITE_USE_MOCK: z.enum(['true', 'false']).optional(),
 })
 
 const parsed = envSchema.safeParse(import.meta.env)
@@ -10,6 +11,11 @@ if (!parsed.success) {
   throw new Error(`Invalid environment variables: ${parsed.error.message}`)
 }
 
+const useMock = parsed.data.VITE_USE_MOCK
+  ? parsed.data.VITE_USE_MOCK === 'true'
+  : import.meta.env.MODE === 'development'
+
 export const env = {
   apiBaseUrl: parsed.data.VITE_API_BASE_URL,
+  useMock,
 } as const

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,1 +1,2 @@
 export { cn } from './utils'
+export { toEpochMs } from './time'

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -1,0 +1,4 @@
+/** Convert a Date to UTC epoch milliseconds — the format all backend time fields expect. */
+export function toEpochMs(date: Date): number {
+  return date.getTime()
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { server } from '@/mocks/server'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string
+  readonly VITE_USE_MOCK?: 'true' | 'false'
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## ✨ 작업 개요

다음 PR(이슈 B — 대시보드 API 연동)에 앞서, **mock으로 디버깅 / 실서버로 배포**를 깔끔하게 토글할 인프라를 먼저 깔았습니다. 핵심은:

- 클라이언트 코드(`useQuery + request()`)는 **분기 없이** 항상 진짜 API 호출처럼 작성
- mock도 axios → 인터셉터 → Zod 검증의 **실제 네트워크 경로 위에서 동작** → mock과 실서버가 구조적으로 어긋나면 즉시 발견
- 토글: `VITE_USE_MOCK` (dev 기본 on, prod 기본 off, 명시 시 우선)
- 오픈소스 친화: 클론 직후 `npm run dev`만으로 mock 대시보드가 작동

## 📝 변경 사항

- **MSW 워커 추가** — `public/mockServiceWorker.js` (커밋), `.gitignore`에서 해제. 클론 후 추가 명령 없이 즉시 동작.
- **env 토글** — `.env`/`.env.example`에 `VITE_USE_MOCK=true` 추가, `src/shared/config/env.ts`에서 Zod로 파싱. 미설정 시 `import.meta.env.MODE`로 결정 (dev=on, prod=off, fail-closed).
- **MSW 핸들러** — `src/mocks/handlers/`에 백엔드 `DashboardController` 명세와 **1:1**로 핸들러 정의:
  - `GET /dashboard/topology` → `mockTopology`
  - `GET /dashboard/metrics?agentId=...` → `mockMetricsByAgent[agentId]` (없으면 404, agentId 누락 시 400)
  - 기존 `entities/{topology,server-metric}/model/mock.ts` 데이터를 그대로 import — 단일 출처, 데이터 중복 0
- **부트스트랩** — `src/main.tsx`에서 `env.useMock`이 true일 때만 `@/mocks/browser`를 **dynamic import** + `worker.start()`. 빌드 산출물에 `browser-*.js` 별도 chunk로 분리되며 prod에서 토글 off면 절대 fetch되지 않음.
- **테스트 setup** — `src/test/setup.ts`에 MSW 노드 서버 라이프사이클 추가. `onUnhandledRequest: 'error'`로 명세 빠진 호출을 테스트 시점에 즉시 발견.
- **시간 헬퍼** — `src/shared/lib/time.ts`에 `toEpochMs(date)` 추가. 백엔드 시간 필드(`Long startTime/endTime`)가 epoch ms(=UTC)를 기대하므로 호출부에서 이 헬퍼를 통일해서 사용 → 의도 명시 + grep 가능.

## 🔗 관련 이슈

Closes #14

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다. (`npm run build`, `npm test`)
- [x] 관련 문서를 업데이트했습니다. (필요한 경우) — 해당 없음
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다. (의존성 순서로 5개 커밋 분리)

## 💬 리뷰어에게

- **백엔드 명세 동기화**: 핸들러 URL/응답 형태는 `seeker-web`의 `DashboardController` + `TopologyDto`/`AgentMetricsDto`를 직접 보고 맞췄습니다. 백엔드 스펙이 바뀌면 `src/mocks/handlers/*.ts` 한 줄과 (이슈 B의) 훅 한 줄을 같이 수정하면 됩니다.